### PR TITLE
feat: update portfolio to reflect Principal Software Engineer role

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -75,7 +75,7 @@ const Sidebar = ({ page }) => (
             </div>
             <div css={pageStyles.name}>Chris Shelton</div>
             <div css={pageStyles.location}>UK - Leeds / London / Remote</div>
-            <div css={pageStyles.title}>Software Engineer</div>
+            <div css={pageStyles.title}>Principal Software Engineer</div>
         </Upper>
         <Middle>
             <Nav page={page}></Nav>

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -2,9 +2,23 @@
     "timeline": [
         {
             "company": "Shell",
-            "title": "Software Engineer",
-            "period": "2022-Present",
-            "description": "Working within the Shell Agile Hub team in London, focusing on product development within environmental solutions, specifically the voluntary carbon market, enabling companies to meet their goals of reducing their net carbon footprint. The tech stack is primarily React, TypeScript, GraphQL, CosmosDB and Azure.",
+            "title": "Principal Software Engineer, LNG Trading",
+            "period": "2026-Present",
+            "description": "Technical leader for data, analytics and AI engineering within LNG Trading. I help lead a globally distributed engineering team supporting Shell LNG Marketing and Trading's Short-Term Trading desks across Europe, the Middle East and Asia. I work closely with Traders and Trading Analysts, combining front-office understanding with strong software engineering to deliver business-critical analytics and applications. The tech stack is primarily Azure, Azure Databricks and Python.",
+            "logo": "shell"
+        },
+        {
+            "company": "Shell",
+            "title": "Principal Software Engineer, Carbon Trading",
+            "period": "2024-2026",
+            "description": "Principal engineer for product development within Shell Trading and Supply's voluntary carbon market, setting technical direction and leading delivery across the team. Alongside this I was tech lead for Shell Energy, EPT from 2023 to 2025, responsible for enterprise service bus architecture and integration across the wider platform. The tech stack was primarily React, TypeScript, GraphQL, CosmosDB and Azure.",
+            "logo": "shell"
+        },
+        {
+            "company": "Shell",
+            "title": "Tech Lead, Trading & Supply (Contract)",
+            "period": "2022-2023",
+            "description": "Tech lead for product development within Shell Trading and Supply, specifically the voluntary carbon market, enabling companies to meet their goals of reducing their net carbon footprint. I worked within a multi-disciplinary team made up of other engineers, BAs, designers, testers, an agile coach and a product manager. The tech stack was primarily React, TypeScript, GraphQL, CosmosDB and Azure.",
             "logo": "shell"
         },
         {
@@ -112,13 +126,17 @@
         "Message queuing systems (RabbitMQ)",
         "Automated unit and integration testing",
         "Web security principles",
-        "DRY / YAGNI"
+        "DRY / YAGNI",
+        "Microsoft Azure",
+        "Azure Databricks",
+        "Python",
+        "Data and analytics engineering",
+        "Technical leadership"
     ],
     "otherSkills": [
         "GraphQL",
         "Kubernetes",
         "Cypress",
-        "Python",
         "Xamarin",
         "Jamstack and Static Site Generators",
         "CSS in JS",

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -9,16 +9,16 @@ import { sizes } from "../styles/variables";
 
 const seo = {
     title: "Home",
-    description: `Home page for Chris Shelton's Portfolio. I am a UK-based software engineer, specialising in full-stack web application development in the JavaScript technology stack.`,
+    description: `Home page for Chris Shelton's Portfolio. I am a UK-based Principal Software Engineer and technical leader, specialising in data, analytics and AI engineering for commodities trading.`,
 };
 
 const headerSection = (
     <div>
         <h1>Portfolio</h1>
         <h2>
-            Specialising in <span className="bold">full-stack</span> web
-            application development in the{" "}
-            <span className="bold">JavaScript</span> technology stack
+            Technical leader specialising in <span className="bold">data</span>,{" "}
+            <span className="bold">analytics</span> and{" "}
+            <span className="bold">AI</span> engineering for commodities trading
         </h2>
     </div>
 );
@@ -45,8 +45,8 @@ const contentSection = (
                 <span role="img" aria-label="Waving hand emoji">
                     &#128075;
                 </span>{" "}
-                I&apos;m Chris &mdash; I&apos;m an enthusiastic software
-                engineer based in the UK.
+                I&apos;m Chris &mdash; I&apos;m a Principal Software Engineer
+                and technical leader based in the UK.
             </p>
             <p className="section-text">
                 My Portfolio aims to outline my skills, experience and
@@ -55,17 +55,16 @@ const contentSection = (
                 me.
             </p>
             <p className="section-text">
-                I graduated from the University of Leeds in Computer Science,
-                and have been in the professional software industry since 2016,
-                with prior experience of working on personal projects and an
-                internship.
+                I&apos;ve been in the professional software industry since 2016,
+                working across software consultancy and global enterprise, and
+                now lead engineering teams delivering business-critical systems.
             </p>
             <p className="section-text">
-                I have a variety of skills and experience in the whole software
-                development life cycle, gained through my professional career
-                and doing projects in my own time. I specialise in full-stack
-                web application development in the JavaScript technology stack,
-                including React, Vue, Node.js and MongoDB.
+                I have broad experience across the whole software development
+                life cycle, from hands-on full-stack development through to
+                technical leadership and architecture. Today I specialise in
+                data, analytics and AI engineering on Azure, with a strong
+                background in full-stack JavaScript and TypeScript.
             </p>
         </PageSection>
         <PageSection heading="Where I Work">
@@ -73,20 +72,24 @@ const contentSection = (
                 <ShellLogo />
             </div>
             <p className="section-text">
-                I am a software engineer for{" "}
+                I am a Principal Software Engineer at{" "}
                 <a
                     href="https://www.shell.co.uk/"
                     className="primary-text-link"
                 >
                     Shell
                 </a>
-                , working as part of the Shell Agile Hub team in London.
+                , working in LNG Trading within Trading &amp; Supply.
             </p>
             <p className="section-text">
-                My team and I focus on product development within environmental
-                solutions, specifically the voluntary carbon market, enabling
-                companies to meet their goals of reducing their net carbon
-                footprint.
+                I help lead a globally distributed engineering team supporting
+                Shell LNG Marketing and Trading&apos;s Short-Term Trading desks
+                across Europe, the Middle East and Asia.
+            </p>
+            <p className="section-text">
+                I work closely with Traders and Trading Analysts, combining
+                front-office understanding with strong software engineering to
+                deliver business-critical analytics and applications.
             </p>
         </PageSection>
         <PageSection heading="A Bit More About Me">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,7 +48,7 @@ const FooterContainer = styled.div`
 
 const seo = {
     title: "Portfolio",
-    description: `The landing page for Chris Shelton's Portfolio. I am a UK-based software engineer, specialising in full-stack web application development in the JavaScript technology stack.`,
+    description: `The landing page for Chris Shelton's Portfolio. I am a UK-based Principal Software Engineer and technical leader, specialising in data, analytics and AI engineering for commodities trading.`,
 };
 
 const IndexPage = () => (
@@ -61,11 +61,13 @@ const IndexPage = () => (
             </div>
             <div css={pageStyles.name}>Chris Shelton</div>
             <div css={pageStyles.location}>UK - Leeds / London / Remote</div>
-            <div css={pageStyles.title}>Software Engineer</div>
+            <div css={pageStyles.title}>Principal Software Engineer</div>
             <p css={pageStyles.experience}>
-                Specialising in <span className="bold">full-stack</span> web
-                application development in the{" "}
-                <span className="bold">JavaScript</span> technology stack
+                Technical leader specialising in{" "}
+                <span className="bold">data</span>,{" "}
+                <span className="bold">analytics</span> and{" "}
+                <span className="bold">AI</span> engineering for commodities
+                trading
             </p>
             <Button mediumLight className="view-portfolio-button" to="/home">
                 <FontAwesomeIcon icon={faChevronCircleRight} /> View Portfolio

--- a/src/pages/skills-and-experience.js
+++ b/src/pages/skills-and-experience.js
@@ -64,31 +64,14 @@ const headerJsx = (
     <div>
         <h1>Skills &amp; Experience</h1>
         <h2>
-            Learn more about my skills &amp; experience as a software engineer
+            Learn more about my skills and experience as a Principal Software
+            Engineer and technical leader
         </h2>
     </div>
 );
 
 const contentJsx = (
     <div>
-        <PageSection heading="Education">
-            <div css={uolLogoContainer}>
-                <UolLogo></UolLogo>
-            </div>
-            <p className="section-text">
-                I proudly graduated from The University of Leeds in 2016, with a
-                First-class (Hons) in Computer Science. I also received an award
-                for academic excellence two years in a row during my time at
-                University.
-            </p>
-            <p className="section-text">
-                I thoroughly enjoyed my degree. I enjoyed the challenges it
-                presented, and the opportunities it has given me for my future.
-                I worked hard, and it paid off, and that has enabled me to do
-                something as a job every day, which feels much more like a
-                hobby.
-            </p>
-        </PageSection>
         <PageSection heading="Professional Experience">
             {experienceData.timeline.map((experience, index) => {
                 return <ExperienceEntry key={index} experience={experience} />;
@@ -139,6 +122,24 @@ const contentJsx = (
                     return <Pill key={index}>{skill}</Pill>;
                 })}
             </div>
+        </PageSection>
+        <PageSection heading="Education">
+            <div css={uolLogoContainer}>
+                <UolLogo></UolLogo>
+            </div>
+            <p className="section-text">
+                I proudly graduated from The University of Leeds in 2016, with a
+                First-class (Hons) in Computer Science. I also received an award
+                for academic excellence two years in a row during my time at
+                University.
+            </p>
+            <p className="section-text">
+                I thoroughly enjoyed my degree. I enjoyed the challenges it
+                presented, and the opportunities it has given me for my future.
+                I worked hard, and it paid off, and that has enabled me to do
+                something as a job every day, which feels much more like a
+                hobby.
+            </p>
         </PageSection>
     </div>
 );


### PR DESCRIPTION
## Why

The site still described an early-career engineer — leading with graduating from Leeds — and listed a single Shell role, "Software Engineer, 2022-Present", working on the voluntary carbon market. That's several years out of date and undersells a decade of experience.

## What changed

**Shell timeline** (`src/data/experience.json`) — one entry becomes three, showing the progression to Principal:

| Period | Title |
|---|---|
| 2026-Present | Principal Software Engineer, LNG Trading |
| 2024-2026 | Principal Software Engineer, Carbon Trading |
| 2022-2023 | Tech Lead, Trading & Supply (Contract) |

The CC Tech Lead role (Sep 2023 – Aug 2025) is folded into the Carbon Trading entry as a concurrent responsibility rather than a fourth entry — the timeline is a flat list, so four entries would have rendered visibly conflicting date ranges. Internal Shell terminology ("CC Tech Lead Shell Energy, EPT") is smoothed for a public audience.

**Positioning** (`src/pages/index.js`, `src/components/sidebar.js`) — title becomes "Principal Software Engineer" and the tagline moves from full-stack JavaScript to technical leadership in data, analytics and AI engineering. This also updates the landing page's SEO and social meta.

**About Me** (`src/pages/home.js`) — graduation framing replaced with career framing; "Where I Work" rewritten for LNG Trading and the Short-Term Trading desks.

**Skills & Experience** (`src/pages/skills-and-experience.js`) — the Education section moves to the bottom of the page, **wording unchanged**. Azure, Databricks, Python, data/analytics engineering and technical leadership added as skill pills; Python promoted out of "Other Skills" so it isn't listed twice.

## Verification

- `npm run build` clean on Node 16.20.2 — 28/28 pages, 27s
- `npx prettier --check` passes on all changed files
- All 7 hippogriff `/application` pages built, so the source-git token path is healthy
- Rendered HTML confirmed: no graduation references remain on `/home`; section order is Professional Experience → Core Skills → Other Skills → Education; all Shell/Bluesmith/UoL logos render

**Worth eyeballing on the deploy preview:** "Principal Software Engineer" is ~50% longer than "Software Engineer" and the title style caps at 22-25px, so check the wrap in the sidebar and on the landing page at narrow widths.

Content-only — no dependency or build config changes. The tech stack upgrade is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)